### PR TITLE
fix: blogsync repo path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang
 
-RUN go get github.com/motemen/blogsync
+RUN go get github.com/x-motemen/blogsync
 
 ENTRYPOINT [ "blogsync" ]


### PR DESCRIPTION
## Summary

1. `npm run pull` (first time)
2. The following error message was displayed.

![CleanShot 2021-03-07 at 18 39 09](https://user-images.githubusercontent.com/706529/110235681-cef48f80-7f74-11eb-91cf-f24743a8dbfc.png)

## Solution
- Fixed blogsync path in Dockerfile.